### PR TITLE
Add custom start page

### DIFF
--- a/src/app/start/page.tsx
+++ b/src/app/start/page.tsx
@@ -1,0 +1,18 @@
+import { QuizEngine } from "@/components/QuizEngine";
+import { LiveHomePreview } from "@/components/LiveHomePreview";
+
+export default function StartPage() {
+  return (
+    <main className="min-h-screen bg-slate-900 text-white px-4 py-10 flex flex-col md:flex-row justify-center items-start gap-8">
+      {/* Left: Quiz */}
+      <div className="w-full md:w-1/2 max-w-lg">
+        <QuizEngine />
+      </div>
+
+      {/* Right: Evolving Home Preview */}
+      <div className="w-full md:w-1/2">
+        <LiveHomePreview />
+      </div>
+    </main>
+  );
+}

--- a/src/components/LiveHomePreview.tsx
+++ b/src/components/LiveHomePreview.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export function LiveHomePreview() {
+  return (
+    <div>
+      <p>Home Preview Placeholder</p>
+    </div>
+  );
+}

--- a/src/components/QuizEngine.tsx
+++ b/src/components/QuizEngine.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export function QuizEngine() {
+  return (
+    <div>
+      <p>Quiz Engine Placeholder</p>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     /* Path Aliases */
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- add start page with quiz and preview
- add minimal placeholder components so page can compile
- configure `@` alias in tsconfig

## Testing
- `pnpm run typecheck`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687272db9c848322bbeb5ca21bd2fbbc