### PR TITLE
Add quiz engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^19.0.0",
     "server-only": "^0.0.1",
     "superjson": "^2.2.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       zod:
         specifier: ^3.24.2
         version: 3.25.76
+      zustand:
+        specifier: ^5.0.6
+        version: 5.0.6(@types/react@19.1.8)(react@19.1.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -1991,6 +1994,24 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@5.0.6:
+    resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -4042,3 +4063,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zustand@5.0.6(@types/react@19.1.8)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.8
+      react: 19.1.0

--- a/src/components/QuizEngine.tsx
+++ b/src/components/QuizEngine.tsx
@@ -1,9 +1,65 @@
 "use client";
 
+import { useState } from "react";
+import { useHomeStore } from "@/state/homeStore";
+
+const questions: {
+  key: string;
+  label: string;
+  options: Array<string | number>;
+}[] = [
+  {
+    key: "bedrooms",
+    label: "How many bedrooms do you want?",
+    options: [2, 3, 4],
+  },
+  {
+    key: "style",
+    label: "Which style do you prefer?",
+    options: ["Modern", "Farmhouse", "Traditional"],
+  },
+  {
+    key: "budget",
+    label: "What’s your budget range?",
+    options: ["Under $100k", "$100k–$150k", "$150k+"],
+  },
+];
+
 export function QuizEngine() {
+  const [step, setStep] = useState(0);
+  const setAnswer = useHomeStore((state) => state.setAnswer);
+
+  const current = questions[step];
+
+  const handleSelect = (value: string | number) => {
+    if (!current) return;
+    setAnswer(current.key, value);
+    setStep((prev) => prev + 1);
+  };
+
+  if (!current) {
+    return (
+      <div className="text-center text-2xl font-semibold text-emerald-400">
+        You&apos;re all set! 🎉<br />
+        Your dream home is shaping up...
+      </div>
+    );
+  }
+
   return (
-    <div>
-      <p>Quiz Engine Placeholder</p>
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold">{current.label}</h2>
+      <div className="flex flex-wrap gap-4">
+        {current.options.map((option) => (
+          <button
+            key={option}
+            onClick={() => handleSelect(option)}
+            className="bg-white text-slate-900 rounded-lg px-6 py-3 text-lg hover:bg-emerald-100 transition-all"
+          >
+            {option}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/state/homeStore.ts
+++ b/src/state/homeStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+export type HomeAnswers = Record<string, string | number>;
+
+interface HomeState {
+  answers: HomeAnswers;
+  setAnswer: (key: string, value: string | number) => void;
+}
+
+export const useHomeStore = create<HomeState>((set) => ({
+  answers: {},
+  setAnswer: (key, value) =>
+    set((state) => ({ answers: { ...state.answers, [key]: value } })),
+}));


### PR DESCRIPTION
## Summary
- implement QuizEngine component with single-question flow
- add Zustand store for quiz answers
- include zustand dependency

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68728debf81c83228449afbc13c3ffbb