### PR TITLE
Add typed Zustand store for quiz answers

### DIFF
--- a/src/components/QuizEngine.tsx
+++ b/src/components/QuizEngine.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { useHomeStore } from "@/state/homeStore";
+import { useHomeStore, type HomeFields } from "@/state/homeStore";
 
 const questions: {
-  key: string;
+  key: keyof HomeFields;
   label: string;
   options: Array<string | number>;
 }[] = [

--- a/src/state/homeStore.ts
+++ b/src/state/homeStore.ts
@@ -1,14 +1,18 @@
 import { create } from "zustand";
 
-export type HomeAnswers = Record<string, string | number>;
+export type HomeFields = {
+  bedrooms: number;
+  style: string;
+  budget: string;
+};
 
-interface HomeState {
-  answers: HomeAnswers;
-  setAnswer: (key: string, value: string | number) => void;
-}
+type HomeState = HomeFields & {
+  setAnswer: <K extends keyof HomeFields>(key: K, value: HomeFields[K]) => void;
+};
 
 export const useHomeStore = create<HomeState>((set) => ({
-  answers: {},
-  setAnswer: (key, value) =>
-    set((state) => ({ answers: { ...state.answers, [key]: value } })),
+  bedrooms: 0,
+  style: "",
+  budget: "",
+  setAnswer: (key, value) => set({ [key]: value }),
 }));


### PR DESCRIPTION
## Summary
- implement a typed Zustand store in `homeStore.ts`
- adjust quiz engine to use typed store keys

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_687293d5bef08322bbe5afdb41e4e349