### PR TITLE
Add homes dynamic page

### DIFF
--- a/src/app/homes/[slug]/page.tsx
+++ b/src/app/homes/[slug]/page.tsx
@@ -1,44 +1,52 @@
 import { notFound } from "next/navigation";
 import Image from "next/image";
 
-// Mock homes
+// 🏠 Mock data (replace with Supabase or CMS later)
 const mockHomes = {
   "sunshine-320-xl": {
     name: "Sunshine 320 XL",
     image: "/homes/sunshine-320.png",
-    description: "Spacious 3-bed, 2-bath layout.",
+    description:
+      "A spacious double-wide home with 3 bedrooms, 2 bathrooms, and modern finishes.",
   },
   "clayton-everest": {
     name: "Clayton Everest",
     image: "/homes/clayton-everest.png",
-    description: "Modern 4-bed with open concept kitchen.",
+    description:
+      "A stylish 4-bedroom layout with an open concept kitchen and flex room.",
   },
 } satisfies Record<string, { name: string; image: string; description: string }>;
 
-export default async function Page({
+// ✅ Async page component — App Router compatible
+export default async function HomePage({
   params,
 }: {
   params: { slug: string };
 }) {
   const home = mockHomes[params.slug as keyof typeof mockHomes];
+
   if (!home) return notFound();
 
   return (
-    <main className="p-10 text-slate-900">
-      <h1 className="text-4xl font-bold">{home.name}</h1>
-      <p className="mt-4 text-lg">{home.description}</p>
-      <div className="mt-6 w-full h-96 relative">
-        <Image
-          src={home.image}
-          alt={home.name}
-          fill
-          className="object-contain rounded-xl"
-        />
+    <main className="min-h-screen bg-white text-slate-900 px-6 py-12">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-extrabold">{home.name}</h1>
+        <p className="mt-4 text-lg text-slate-600">{home.description}</p>
+
+        <div className="mt-8 w-full h-[400px] relative">
+          <Image
+            src={home.image}
+            alt={home.name}
+            fill
+            className="object-contain rounded-xl shadow-xl"
+          />
+        </div>
       </div>
     </main>
   );
 }
 
+// ✅ Required for static site generation in app/ directory
 export async function generateStaticParams() {
   return Object.keys(mockHomes).map((slug) => ({ slug }));
 }


### PR DESCRIPTION
## Summary
- add dynamic page for home details

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6872b44b3bb4832296a01f01c820c6fd