### PR TITLE
Add hero carousel above quiz layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import { useState, useEffect } from "react";
 import { QuizEngine } from "@/components/QuizEngine";


### PR DESCRIPTION
## Summary
- add a simple rotating `HeroCarousel` component to the home page
- display quiz and live preview side by side

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68730427d3288322baf3222d671f7603