### PR TITLE
Add static homes pages

### DIFF
--- a/src/app/homes/[id]/ClientHomePage.tsx
+++ b/src/app/homes/[id]/ClientHomePage.tsx
@@ -6,9 +6,14 @@ import { useHomeStore } from "@/state/homeStore";
 
 interface Props {
   id: string;
+  homeData: {
+    id: number;
+    name: string;
+    [key: string]: unknown;
+  };
 }
 
-export default function ClientHomePage({ id }: Props) {
+export default function ClientHomePage({ id, homeData }: Props) {
   const setAnswer = useHomeStore((state) => state.setAnswer);
 
   useEffect(() => {
@@ -20,7 +25,7 @@ export default function ClientHomePage({ id }: Props) {
 
   return (
     <main className="min-h-screen bg-white px-8 py-12">
-      <h1 className="text-3xl font-bold mb-6">Home #{id} Preview</h1>
+      <h1 className="text-3xl font-bold mb-6">{homeData.name}</h1>
       <LiveHomePreview />
     </main>
   );

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -1,10 +1,12 @@
+// src/app/homes/[id]/page.tsx
 import ClientHomePage from "./ClientHomePage";
+import homesData from "@/data/homes.json";
+import { notFound } from "next/navigation";
 
-// Pre-generate IDs 1–1000 for static pages
+// Generate one static page per entry in homes.json
 export async function generateStaticParams() {
-  const total = 1000;
-  return Array.from({ length: total }, (_, i) => ({
-    id: String(i + 1),
+  return homesData.map((home) => ({
+    id: home.id.toString(),
   }));
 }
 
@@ -14,5 +16,7 @@ export default async function HomePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  return <ClientHomePage id={id} />;
+  const home = homesData.find((h) => h.id.toString() === id);
+  if (!home) notFound();
+  return <ClientHomePage id={id} homeData={home} />;
 }

--- a/src/data/homes.json
+++ b/src/data/homes.json
@@ -1,0 +1,802 @@
+[
+  {
+    "id": 1,
+    "name": "Home 1"
+  },
+  {
+    "id": 2,
+    "name": "Home 2"
+  },
+  {
+    "id": 3,
+    "name": "Home 3"
+  },
+  {
+    "id": 4,
+    "name": "Home 4"
+  },
+  {
+    "id": 5,
+    "name": "Home 5"
+  },
+  {
+    "id": 6,
+    "name": "Home 6"
+  },
+  {
+    "id": 7,
+    "name": "Home 7"
+  },
+  {
+    "id": 8,
+    "name": "Home 8"
+  },
+  {
+    "id": 9,
+    "name": "Home 9"
+  },
+  {
+    "id": 10,
+    "name": "Home 10"
+  },
+  {
+    "id": 11,
+    "name": "Home 11"
+  },
+  {
+    "id": 12,
+    "name": "Home 12"
+  },
+  {
+    "id": 13,
+    "name": "Home 13"
+  },
+  {
+    "id": 14,
+    "name": "Home 14"
+  },
+  {
+    "id": 15,
+    "name": "Home 15"
+  },
+  {
+    "id": 16,
+    "name": "Home 16"
+  },
+  {
+    "id": 17,
+    "name": "Home 17"
+  },
+  {
+    "id": 18,
+    "name": "Home 18"
+  },
+  {
+    "id": 19,
+    "name": "Home 19"
+  },
+  {
+    "id": 20,
+    "name": "Home 20"
+  },
+  {
+    "id": 21,
+    "name": "Home 21"
+  },
+  {
+    "id": 22,
+    "name": "Home 22"
+  },
+  {
+    "id": 23,
+    "name": "Home 23"
+  },
+  {
+    "id": 24,
+    "name": "Home 24"
+  },
+  {
+    "id": 25,
+    "name": "Home 25"
+  },
+  {
+    "id": 26,
+    "name": "Home 26"
+  },
+  {
+    "id": 27,
+    "name": "Home 27"
+  },
+  {
+    "id": 28,
+    "name": "Home 28"
+  },
+  {
+    "id": 29,
+    "name": "Home 29"
+  },
+  {
+    "id": 30,
+    "name": "Home 30"
+  },
+  {
+    "id": 31,
+    "name": "Home 31"
+  },
+  {
+    "id": 32,
+    "name": "Home 32"
+  },
+  {
+    "id": 33,
+    "name": "Home 33"
+  },
+  {
+    "id": 34,
+    "name": "Home 34"
+  },
+  {
+    "id": 35,
+    "name": "Home 35"
+  },
+  {
+    "id": 36,
+    "name": "Home 36"
+  },
+  {
+    "id": 37,
+    "name": "Home 37"
+  },
+  {
+    "id": 38,
+    "name": "Home 38"
+  },
+  {
+    "id": 39,
+    "name": "Home 39"
+  },
+  {
+    "id": 40,
+    "name": "Home 40"
+  },
+  {
+    "id": 41,
+    "name": "Home 41"
+  },
+  {
+    "id": 42,
+    "name": "Home 42"
+  },
+  {
+    "id": 43,
+    "name": "Home 43"
+  },
+  {
+    "id": 44,
+    "name": "Home 44"
+  },
+  {
+    "id": 45,
+    "name": "Home 45"
+  },
+  {
+    "id": 46,
+    "name": "Home 46"
+  },
+  {
+    "id": 47,
+    "name": "Home 47"
+  },
+  {
+    "id": 48,
+    "name": "Home 48"
+  },
+  {
+    "id": 49,
+    "name": "Home 49"
+  },
+  {
+    "id": 50,
+    "name": "Home 50"
+  },
+  {
+    "id": 51,
+    "name": "Home 51"
+  },
+  {
+    "id": 52,
+    "name": "Home 52"
+  },
+  {
+    "id": 53,
+    "name": "Home 53"
+  },
+  {
+    "id": 54,
+    "name": "Home 54"
+  },
+  {
+    "id": 55,
+    "name": "Home 55"
+  },
+  {
+    "id": 56,
+    "name": "Home 56"
+  },
+  {
+    "id": 57,
+    "name": "Home 57"
+  },
+  {
+    "id": 58,
+    "name": "Home 58"
+  },
+  {
+    "id": 59,
+    "name": "Home 59"
+  },
+  {
+    "id": 60,
+    "name": "Home 60"
+  },
+  {
+    "id": 61,
+    "name": "Home 61"
+  },
+  {
+    "id": 62,
+    "name": "Home 62"
+  },
+  {
+    "id": 63,
+    "name": "Home 63"
+  },
+  {
+    "id": 64,
+    "name": "Home 64"
+  },
+  {
+    "id": 65,
+    "name": "Home 65"
+  },
+  {
+    "id": 66,
+    "name": "Home 66"
+  },
+  {
+    "id": 67,
+    "name": "Home 67"
+  },
+  {
+    "id": 68,
+    "name": "Home 68"
+  },
+  {
+    "id": 69,
+    "name": "Home 69"
+  },
+  {
+    "id": 70,
+    "name": "Home 70"
+  },
+  {
+    "id": 71,
+    "name": "Home 71"
+  },
+  {
+    "id": 72,
+    "name": "Home 72"
+  },
+  {
+    "id": 73,
+    "name": "Home 73"
+  },
+  {
+    "id": 74,
+    "name": "Home 74"
+  },
+  {
+    "id": 75,
+    "name": "Home 75"
+  },
+  {
+    "id": 76,
+    "name": "Home 76"
+  },
+  {
+    "id": 77,
+    "name": "Home 77"
+  },
+  {
+    "id": 78,
+    "name": "Home 78"
+  },
+  {
+    "id": 79,
+    "name": "Home 79"
+  },
+  {
+    "id": 80,
+    "name": "Home 80"
+  },
+  {
+    "id": 81,
+    "name": "Home 81"
+  },
+  {
+    "id": 82,
+    "name": "Home 82"
+  },
+  {
+    "id": 83,
+    "name": "Home 83"
+  },
+  {
+    "id": 84,
+    "name": "Home 84"
+  },
+  {
+    "id": 85,
+    "name": "Home 85"
+  },
+  {
+    "id": 86,
+    "name": "Home 86"
+  },
+  {
+    "id": 87,
+    "name": "Home 87"
+  },
+  {
+    "id": 88,
+    "name": "Home 88"
+  },
+  {
+    "id": 89,
+    "name": "Home 89"
+  },
+  {
+    "id": 90,
+    "name": "Home 90"
+  },
+  {
+    "id": 91,
+    "name": "Home 91"
+  },
+  {
+    "id": 92,
+    "name": "Home 92"
+  },
+  {
+    "id": 93,
+    "name": "Home 93"
+  },
+  {
+    "id": 94,
+    "name": "Home 94"
+  },
+  {
+    "id": 95,
+    "name": "Home 95"
+  },
+  {
+    "id": 96,
+    "name": "Home 96"
+  },
+  {
+    "id": 97,
+    "name": "Home 97"
+  },
+  {
+    "id": 98,
+    "name": "Home 98"
+  },
+  {
+    "id": 99,
+    "name": "Home 99"
+  },
+  {
+    "id": 100,
+    "name": "Home 100"
+  },
+  {
+    "id": 101,
+    "name": "Home 101"
+  },
+  {
+    "id": 102,
+    "name": "Home 102"
+  },
+  {
+    "id": 103,
+    "name": "Home 103"
+  },
+  {
+    "id": 104,
+    "name": "Home 104"
+  },
+  {
+    "id": 105,
+    "name": "Home 105"
+  },
+  {
+    "id": 106,
+    "name": "Home 106"
+  },
+  {
+    "id": 107,
+    "name": "Home 107"
+  },
+  {
+    "id": 108,
+    "name": "Home 108"
+  },
+  {
+    "id": 109,
+    "name": "Home 109"
+  },
+  {
+    "id": 110,
+    "name": "Home 110"
+  },
+  {
+    "id": 111,
+    "name": "Home 111"
+  },
+  {
+    "id": 112,
+    "name": "Home 112"
+  },
+  {
+    "id": 113,
+    "name": "Home 113"
+  },
+  {
+    "id": 114,
+    "name": "Home 114"
+  },
+  {
+    "id": 115,
+    "name": "Home 115"
+  },
+  {
+    "id": 116,
+    "name": "Home 116"
+  },
+  {
+    "id": 117,
+    "name": "Home 117"
+  },
+  {
+    "id": 118,
+    "name": "Home 118"
+  },
+  {
+    "id": 119,
+    "name": "Home 119"
+  },
+  {
+    "id": 120,
+    "name": "Home 120"
+  },
+  {
+    "id": 121,
+    "name": "Home 121"
+  },
+  {
+    "id": 122,
+    "name": "Home 122"
+  },
+  {
+    "id": 123,
+    "name": "Home 123"
+  },
+  {
+    "id": 124,
+    "name": "Home 124"
+  },
+  {
+    "id": 125,
+    "name": "Home 125"
+  },
+  {
+    "id": 126,
+    "name": "Home 126"
+  },
+  {
+    "id": 127,
+    "name": "Home 127"
+  },
+  {
+    "id": 128,
+    "name": "Home 128"
+  },
+  {
+    "id": 129,
+    "name": "Home 129"
+  },
+  {
+    "id": 130,
+    "name": "Home 130"
+  },
+  {
+    "id": 131,
+    "name": "Home 131"
+  },
+  {
+    "id": 132,
+    "name": "Home 132"
+  },
+  {
+    "id": 133,
+    "name": "Home 133"
+  },
+  {
+    "id": 134,
+    "name": "Home 134"
+  },
+  {
+    "id": 135,
+    "name": "Home 135"
+  },
+  {
+    "id": 136,
+    "name": "Home 136"
+  },
+  {
+    "id": 137,
+    "name": "Home 137"
+  },
+  {
+    "id": 138,
+    "name": "Home 138"
+  },
+  {
+    "id": 139,
+    "name": "Home 139"
+  },
+  {
+    "id": 140,
+    "name": "Home 140"
+  },
+  {
+    "id": 141,
+    "name": "Home 141"
+  },
+  {
+    "id": 142,
+    "name": "Home 142"
+  },
+  {
+    "id": 143,
+    "name": "Home 143"
+  },
+  {
+    "id": 144,
+    "name": "Home 144"
+  },
+  {
+    "id": 145,
+    "name": "Home 145"
+  },
+  {
+    "id": 146,
+    "name": "Home 146"
+  },
+  {
+    "id": 147,
+    "name": "Home 147"
+  },
+  {
+    "id": 148,
+    "name": "Home 148"
+  },
+  {
+    "id": 149,
+    "name": "Home 149"
+  },
+  {
+    "id": 150,
+    "name": "Home 150"
+  },
+  {
+    "id": 151,
+    "name": "Home 151"
+  },
+  {
+    "id": 152,
+    "name": "Home 152"
+  },
+  {
+    "id": 153,
+    "name": "Home 153"
+  },
+  {
+    "id": 154,
+    "name": "Home 154"
+  },
+  {
+    "id": 155,
+    "name": "Home 155"
+  },
+  {
+    "id": 156,
+    "name": "Home 156"
+  },
+  {
+    "id": 157,
+    "name": "Home 157"
+  },
+  {
+    "id": 158,
+    "name": "Home 158"
+  },
+  {
+    "id": 159,
+    "name": "Home 159"
+  },
+  {
+    "id": 160,
+    "name": "Home 160"
+  },
+  {
+    "id": 161,
+    "name": "Home 161"
+  },
+  {
+    "id": 162,
+    "name": "Home 162"
+  },
+  {
+    "id": 163,
+    "name": "Home 163"
+  },
+  {
+    "id": 164,
+    "name": "Home 164"
+  },
+  {
+    "id": 165,
+    "name": "Home 165"
+  },
+  {
+    "id": 166,
+    "name": "Home 166"
+  },
+  {
+    "id": 167,
+    "name": "Home 167"
+  },
+  {
+    "id": 168,
+    "name": "Home 168"
+  },
+  {
+    "id": 169,
+    "name": "Home 169"
+  },
+  {
+    "id": 170,
+    "name": "Home 170"
+  },
+  {
+    "id": 171,
+    "name": "Home 171"
+  },
+  {
+    "id": 172,
+    "name": "Home 172"
+  },
+  {
+    "id": 173,
+    "name": "Home 173"
+  },
+  {
+    "id": 174,
+    "name": "Home 174"
+  },
+  {
+    "id": 175,
+    "name": "Home 175"
+  },
+  {
+    "id": 176,
+    "name": "Home 176"
+  },
+  {
+    "id": 177,
+    "name": "Home 177"
+  },
+  {
+    "id": 178,
+    "name": "Home 178"
+  },
+  {
+    "id": 179,
+    "name": "Home 179"
+  },
+  {
+    "id": 180,
+    "name": "Home 180"
+  },
+  {
+    "id": 181,
+    "name": "Home 181"
+  },
+  {
+    "id": 182,
+    "name": "Home 182"
+  },
+  {
+    "id": 183,
+    "name": "Home 183"
+  },
+  {
+    "id": 184,
+    "name": "Home 184"
+  },
+  {
+    "id": 185,
+    "name": "Home 185"
+  },
+  {
+    "id": 186,
+    "name": "Home 186"
+  },
+  {
+    "id": 187,
+    "name": "Home 187"
+  },
+  {
+    "id": 188,
+    "name": "Home 188"
+  },
+  {
+    "id": 189,
+    "name": "Home 189"
+  },
+  {
+    "id": 190,
+    "name": "Home 190"
+  },
+  {
+    "id": 191,
+    "name": "Home 191"
+  },
+  {
+    "id": 192,
+    "name": "Home 192"
+  },
+  {
+    "id": 193,
+    "name": "Home 193"
+  },
+  {
+    "id": 194,
+    "name": "Home 194"
+  },
+  {
+    "id": 195,
+    "name": "Home 195"
+  },
+  {
+    "id": 196,
+    "name": "Home 196"
+  },
+  {
+    "id": 197,
+    "name": "Home 197"
+  },
+  {
+    "id": 198,
+    "name": "Home 198"
+  },
+  {
+    "id": 199,
+    "name": "Home 199"
+  },
+  {
+    "id": 200,
+    "name": "Home 200"
+  }
+]


### PR DESCRIPTION
## Summary
- create homes data source
- update ClientHomePage to accept and display home data
- implement dynamic route for `/homes/[id]` using that data

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68731e6b9b288322a6d6198365206731