### PR TITLE
Add contact form modal

### DIFF
--- a/src/components/ContactFormModal.tsx
+++ b/src/components/ContactFormModal.tsx
@@ -1,0 +1,62 @@
+// src/components/ContactFormModal.tsx
+"use client";
+
+import type { FC } from "react";
+
+interface Props {
+  data: { name: string; email: string; phone: string };
+  onChange: (field: keyof Props["data"], value: string) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+}
+
+const ContactFormModal: FC<Props> = ({ data, onChange, onSubmit, onClose }) => (
+  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div className="bg-white p-6 rounded-lg w-11/12 max-w-md">
+      <h2 className="text-xl font-bold mb-4">Shoot us your info</h2>
+      <label className="block mb-2">
+        <span>Name</span>
+        <input
+          type="text"
+          value={data.name}
+          onChange={(e) => onChange("name", e.target.value)}
+          className="w-full mt-1 p-2 border rounded"
+        />
+      </label>
+      <label className="block mb-2">
+        <span>Email</span>
+        <input
+          type="email"
+          value={data.email}
+          onChange={(e) => onChange("email", e.target.value)}
+          className="w-full mt-1 p-2 border rounded"
+        />
+      </label>
+      <label className="block mb-4">
+        <span>Phone</span>
+        <input
+          type="tel"
+          value={data.phone}
+          onChange={(e) => onChange("phone", e.target.value)}
+          className="w-full mt-1 p-2 border rounded"
+        />
+      </label>
+      <div className="flex justify-end space-x-2">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 border rounded hover:bg-gray-100"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onSubmit}
+          className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700"
+        >
+          View My Home
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default ContactFormModal;

--- a/src/components/QuizEngine.tsx
+++ b/src/components/QuizEngine.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { useHomeStore } from "@/state/homeStore";
+import { useRouter } from "next/navigation";
+import ContactFormModal from "./ContactFormModal";
 
 const questions: {
   key: "bedrooms" | "style" | "budget";
@@ -28,6 +30,9 @@ const questions: {
 export function QuizEngine() {
   const [step, setStep] = useState(0);
   const setAnswer = useHomeStore((state) => state.setAnswer);
+  const [showForm, setShowForm] = useState(false);
+  const [formData, setFormData] = useState({ name: "", email: "", phone: "" });
+  const router = useRouter();
 
   const current = questions[step];
 
@@ -38,28 +43,50 @@ export function QuizEngine() {
   };
 
   if (!current) {
+    // Quiz complete → show contact form
     return (
-      <div className="text-center text-2xl font-semibold text-emerald-400">
-        You&apos;re all set! 🎉<br />
-        Your dream home is shaping up...
-      </div>
+      <>
+        <ContactFormModal
+          data={formData}
+          onChange={(key, value) =>
+            setFormData((d) => ({ ...d, [key]: value }))
+          }
+          onSubmit={() => {
+            // TODO: replace '1' with the correct home ID generated from answers
+            router.push(`/homes/1`);
+          }}
+          onClose={() => setShowForm(false)}
+        />
+      </>
     );
   }
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-2xl font-bold">{current.label}</h2>
-      <div className="flex flex-wrap gap-4">
-        {current.options.map((option) => (
-          <button
-            key={option}
-            onClick={() => handleSelect(option)}
-            className="bg-white text-slate-900 rounded-lg px-6 py-3 text-lg hover:bg-emerald-100 transition-all"
-          >
-            {option}
-          </button>
-        ))}
+    <>
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold">{current.label}</h2>
+        <div className="flex flex-wrap gap-4">
+          {current.options.map((option) => (
+            <button
+              key={option}
+              onClick={() => handleSelect(option)}
+              className="bg-white text-slate-900 rounded-lg px-6 py-3 text-lg hover:bg-emerald-100 transition-all"
+            >
+              {option}
+            </button>
+          ))}
+        </div>
       </div>
-    </div>
+      {showForm && (
+        <ContactFormModal
+          data={formData}
+          onChange={(key, value) =>
+            setFormData((d) => ({ ...d, [key]: value }))
+          }
+          onSubmit={() => router.push(`/homes/1`)}
+          onClose={() => setShowForm(false)}
+        />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add contact form modal component
- display modal on quiz completion
- wire modal to optional show/hide from QuizEngine

## Testing
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68742c1ec1308322a5e8e1330df97aeb