### PR TITLE
Add home mapping API and style fix

### DIFF
--- a/src/app/api/map-home/route.ts
+++ b/src/app/api/map-home/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import mapping from "@/data/homeMapping.json";
+
+export async function POST(req: Request) {
+  const { bedrooms, style, budget } = (await req.json()) as {
+    bedrooms: number;
+    style: string;
+    budget: string;
+  };
+  const key = `${bedrooms}-${style}-${budget}`;
+  const entry = mapping.find((e) => e.key === key);
+  if (!entry) {
+    return NextResponse.json({ error: "No mapping for " + key }, { status: 404 });
+  }
+  return NextResponse.json({ homeId: entry.homeId });
+}
+

--- a/src/components/QuizEngine.tsx
+++ b/src/components/QuizEngine.tsx
@@ -64,7 +64,7 @@ export function QuizEngine() {
   return (
     <>
       <div className="space-y-6">
-        <h2 className="text-2xl font-bold">{current.label}</h2>
+        <h2 className="text-2xl font-bold text-slate-900">{current.label}</h2>
         <div className="flex flex-wrap gap-4">
           {current.options.map((option) => (
             <button

--- a/src/data/homeMapping.json
+++ b/src/data/homeMapping.json
@@ -1,0 +1,110 @@
+[
+  {
+    "key": "2-Modern-Under $100k",
+    "homeId": 1
+  },
+  {
+    "key": "2-Modern-$100k–$150k",
+    "homeId": 2
+  },
+  {
+    "key": "2-Modern-$150k+",
+    "homeId": 3
+  },
+  {
+    "key": "2-Farmhouse-Under $100k",
+    "homeId": 4
+  },
+  {
+    "key": "2-Farmhouse-$100k–$150k",
+    "homeId": 5
+  },
+  {
+    "key": "2-Farmhouse-$150k+",
+    "homeId": 6
+  },
+  {
+    "key": "2-Traditional-Under $100k",
+    "homeId": 7
+  },
+  {
+    "key": "2-Traditional-$100k–$150k",
+    "homeId": 8
+  },
+  {
+    "key": "2-Traditional-$150k+",
+    "homeId": 9
+  },
+  {
+    "key": "3-Modern-Under $100k",
+    "homeId": 10
+  },
+  {
+    "key": "3-Modern-$100k–$150k",
+    "homeId": 11
+  },
+  {
+    "key": "3-Modern-$150k+",
+    "homeId": 12
+  },
+  {
+    "key": "3-Farmhouse-Under $100k",
+    "homeId": 13
+  },
+  {
+    "key": "3-Farmhouse-$100k–$150k",
+    "homeId": 14
+  },
+  {
+    "key": "3-Farmhouse-$150k+",
+    "homeId": 15
+  },
+  {
+    "key": "3-Traditional-Under $100k",
+    "homeId": 16
+  },
+  {
+    "key": "3-Traditional-$100k–$150k",
+    "homeId": 17
+  },
+  {
+    "key": "3-Traditional-$150k+",
+    "homeId": 18
+  },
+  {
+    "key": "4-Modern-Under $100k",
+    "homeId": 19
+  },
+  {
+    "key": "4-Modern-$100k–$150k",
+    "homeId": 20
+  },
+  {
+    "key": "4-Modern-$150k+",
+    "homeId": 21
+  },
+  {
+    "key": "4-Farmhouse-Under $100k",
+    "homeId": 22
+  },
+  {
+    "key": "4-Farmhouse-$100k–$150k",
+    "homeId": 23
+  },
+  {
+    "key": "4-Farmhouse-$150k+",
+    "homeId": 24
+  },
+  {
+    "key": "4-Traditional-Under $100k",
+    "homeId": 25
+  },
+  {
+    "key": "4-Traditional-$100k–$150k",
+    "homeId": 26
+  },
+  {
+    "key": "4-Traditional-$150k+",
+    "homeId": 27
+  }
+]


### PR DESCRIPTION
## Summary
- expose new `/api/map-home` endpoint for looking up home IDs
- make quiz question text dark for better contrast

## Testing
- `pnpm run check`


------
https://chatgpt.com/codex/tasks/task_b_687434979f1c8322a20e41c1fbf9ed0f