### PR TITLE
Enable dynamic home mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ You can check out the [create-t3-app GitHub repository](https://github.com/t3-os
 ## How do I deploy this?
 
 Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel), [Netlify](https://create.t3.gg/en/deployment/netlify) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
+
+## Mapping quiz answers to home pages
+
+Quiz responses are mapped to specific home pages via
+`src/data/homeMapping.json`. Each entry links a combination of bedroom count,
+style and budget to a `homeId`. The `/api/map-home` endpoint reads this file and
+returns the matching `homeId`.
+
+To change which home page a set of answers should redirect to, edit
+`homeMapping.json` and redeploy. Alternatively you can update the endpoint to
+pull mappings from a database or CMS.

--- a/src/components/QuizEngine.tsx
+++ b/src/components/QuizEngine.tsx
@@ -51,9 +51,23 @@ export function QuizEngine() {
           onChange={(key, value) =>
             setFormData((d) => ({ ...d, [key]: value }))
           }
-          onSubmit={() => {
-            // TODO: replace '1' with the correct home ID generated from answers
-            router.push(`/homes/1`);
+          onSubmit={async () => {
+            const { bedrooms, style, budget } = useHomeStore.getState();
+            try {
+              const res = await fetch("/api/map-home", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ bedrooms, style, budget }),
+              });
+              if (res.ok) {
+                const { homeId } = (await res.json()) as { homeId: number };
+                router.push(`/homes/${homeId}`);
+              } else {
+                console.error(await res.text());
+              }
+            } catch (err) {
+              console.error(err);
+            }
           }}
           onClose={() => setShowForm(false)}
         />
@@ -70,7 +84,7 @@ export function QuizEngine() {
             <button
               key={option}
               onClick={() => handleSelect(option)}
-              className="bg-white text-slate-900 rounded-lg px-6 py-3 text-lg hover:bg-emerald-100 transition-all"
+              className="rounded-lg bg-white px-6 py-3 text-lg text-slate-900 transition-all hover:bg-emerald-100"
             >
               {option}
             </button>
@@ -83,7 +97,24 @@ export function QuizEngine() {
           onChange={(key, value) =>
             setFormData((d) => ({ ...d, [key]: value }))
           }
-          onSubmit={() => router.push(`/homes/1`)}
+          onSubmit={async () => {
+            const { bedrooms, style, budget } = useHomeStore.getState();
+            try {
+              const res = await fetch("/api/map-home", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ bedrooms, style, budget }),
+              });
+              if (res.ok) {
+                const { homeId } = (await res.json()) as { homeId: number };
+                router.push(`/homes/${homeId}`);
+              } else {
+                console.error(await res.text());
+              }
+            } catch (err) {
+              console.error(err);
+            }
+          }}
           onClose={() => setShowForm(false)}
         />
       )}


### PR DESCRIPTION
## Summary
- implement API-based home redirect in `QuizEngine`
- document mapping workflow in README

## Testing
- `pnpm run check`

------
https://chatgpt.com/codex/tasks/task_b_68743aba188c8322bf9a2e3013efd427