### PR TITLE
Add API routes with in-memory home data

### DIFF
--- a/src/app/api/homes/[id]/route.ts
+++ b/src/app/api/homes/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getHome, updateHome, type Home } from "@/data/homesStore";
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const home = getHome(+params.id);
+  if (!home) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(home);
+}
+
+export async function PUT(req: Request, { params }: { params: { id: string } }) {
+  const updates = (await req.json()) as Partial<Home>;
+  const updated = updateHome({ ...(updates as Home), id: +params.id });
+  return NextResponse.json(updated);
+}

--- a/src/app/api/homes/route.ts
+++ b/src/app/api/homes/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { getAllHomes, updateHome, type Home } from "@/data/homesStore";
+
+export async function GET() {
+  return NextResponse.json(getAllHomes());
+}
+
+export async function POST(req: Request) {
+  const newHome = (await req.json()) as Home;
+  updateHome(newHome);
+  return NextResponse.json(newHome);
+}

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -1,20 +1,10 @@
 // src/app/homes/[id]/page.tsx
 import ClientHomePage from "./ClientHomePage";
-import homesData from "@/data/homes.json";
+import { getHome } from "@/data/homesStore";
 import { notFound } from "next/navigation";
 
-// Build pages for IDs 1–5 from homes.json
-export async function generateStaticParams() {
-  return homesData.map((h) => ({ id: h.id.toString() }));
-}
-
-export default async function HomePage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = await params;
-  const home = homesData.find((h) => h.id.toString() === id);
+export default function HomePage({ params }: { params: { id: string } }) {
+  const home = getHome(+params.id);
   if (!home) notFound();
-  return <ClientHomePage id={id} homeData={home} />;
+  return <ClientHomePage id={params.id} homeData={home} />;
 }

--- a/src/app/homes/page.tsx
+++ b/src/app/homes/page.tsx
@@ -1,8 +1,9 @@
 // src/app/homes/page.tsx
 import Link from "next/link";
-import homesData from "@/data/homes.json";
+import { getAllHomes } from "@/data/homesStore";
 
 export default function HomesIndex() {
+  const homesData = getAllHomes();
   return (
     <main className="min-h-screen bg-white px-8 py-12">
       <h1 className="text-4xl font-bold mb-8">Demo Homes</h1>

--- a/src/data/homesStore.ts
+++ b/src/data/homesStore.ts
@@ -1,0 +1,70 @@
+export type Home = {
+  id: number;
+  bedrooms: number;
+  style: string;
+  budget: string;
+  image: string;
+  listings: { title: string; price: string }[];
+};
+
+let homes: Home[] = [
+  {
+    id: 1,
+    bedrooms: 2,
+    style: "Modern",
+    budget: "Under $100k",
+    image: "/sunshine-320.png",
+    listings: [
+      { title: "Cozy Corner", price: "$90k" },
+      { title: "Riverside View", price: "$95k" },
+    ],
+  },
+  {
+    id: 2,
+    bedrooms: 3,
+    style: "Farmhouse",
+    budget: "$100k–$150k",
+    image: "/clayton-everest.png",
+    listings: [{ title: "Country Charm", price: "$120k" }],
+  },
+  {
+    id: 3,
+    bedrooms: 4,
+    style: "Traditional",
+    budget: "$150k+",
+    image: "/home-placeholder.png",
+    listings: [
+      { title: "Grand Retreat", price: "$160k" },
+      { title: "Lake House", price: "$175k" },
+    ],
+  },
+  {
+    id: 4,
+    bedrooms: 3,
+    style: "Modern",
+    budget: "$150k+",
+    image: "/sunshine-320.png",
+    listings: [{ title: "Urban Oasis", price: "$155k" }],
+  },
+  {
+    id: 5,
+    bedrooms: 2,
+    style: "Farmhouse",
+    budget: "Under $100k",
+    image: "/clayton-everest.png",
+    listings: [{ title: "Cozy Cottage", price: "$85k" }],
+  },
+];
+
+export function getAllHomes() {
+  return homes;
+}
+
+export function getHome(id: number) {
+  return homes.find((h) => h.id === id);
+}
+
+export function updateHome(updated: Home) {
+  homes = homes.map((h) => (h.id === updated.id ? updated : h));
+  return updated;
+}


### PR DESCRIPTION
## Summary
- introduce `homesStore` with demo data and helper functions
- expose `/api/homes` and `/api/homes/[id]` endpoints
- load home pages from the in-memory store instead of JSON

## Testing
- `pnpm lint`
- `npx -y tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_6874513633c483229e8a00436ce97cbf