### PR TITLE
Ensure edited homes persist across routes

### DIFF
--- a/src/app/api/homes/[id]/route.ts
+++ b/src/app/api/homes/[id]/route.ts
@@ -1,0 +1,23 @@
+// src/app/api/homes/[id]/route.ts
+import { NextResponse } from "next/server";
+import { getHome, updateHome, type Home } from "@/data/homesStore";
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const home = getHome(Number(id));
+  if (!home) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(home);
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const body = (await req.json()) as unknown;
+  const updates = body as Home;
+  const updated = updateHome({ ...updates, id: Number(id) });
+  return NextResponse.json(updated);
+}

--- a/src/app/api/homes/route.ts
+++ b/src/app/api/homes/route.ts
@@ -1,0 +1,16 @@
+// src/app/api/homes/route.ts
+import { NextResponse } from "next/server";
+import { getAllHomes, updateHome, type Home } from "@/data/homesStore";
+
+export async function GET() {
+  // Return the full list of homes
+  return NextResponse.json(getAllHomes());
+}
+
+export async function POST(req: Request) {
+  // Create or update via POST (body must include id and all fields)
+  const body = (await req.json()) as unknown;
+  const home = body as Home;
+  const updated = updateHome(home);
+  return NextResponse.json(updated);
+}

--- a/src/app/homes/[id]/ClientHomePage.tsx
+++ b/src/app/homes/[id]/ClientHomePage.tsx
@@ -1,56 +1,167 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { LiveHomePreview } from "@/components/LiveHomePreview";
 import { useHomeStore } from "@/state/homeStore";
 
+interface HomeData {
+  id: number;
+  bedrooms: number;
+  style: string;
+  budget: string;
+  image: string;
+  listings: { title: string; price: string }[];
+}
+
 interface Props {
   id: string;
-  homeData: {
-    id: number;
-    bedrooms: number;
-    style: string;
-    budget: string;
-    image: string;
-    listings: { title: string; price: string }[];
-  };
+  homeData: HomeData;
 }
 
 export default function ClientHomePage({ id, homeData }: Props) {
+  const router = useRouter();
   const setAnswer = useHomeStore((s) => s.setAnswer);
 
+  // Local state for edit form
+  const [editMode, setEditMode] = useState(false);
+  const [form, setForm] = useState<HomeData>(homeData);
+  const [saving, setSaving] = useState(false);
+
+  // Seed Zustand for the preview
   useEffect(() => {
-    // Seed global state with this home’s data
-    setAnswer("bedrooms", homeData.bedrooms);
-    setAnswer("style", homeData.style);
-    setAnswer("budget", homeData.budget);
-  }, [id, homeData, setAnswer]);
+    setAnswer("bedrooms", form.bedrooms);
+    setAnswer("style", form.style);
+    setAnswer("budget", form.budget);
+  }, [form, setAnswer]);
+
+  // Handle input changes
+  const onChange = <K extends keyof HomeData>(key: K, value: HomeData[K]) => {
+    setForm((f) => ({ ...f, [key]: value }));
+  };
+
+  // Save back to API and refresh
+  const onSave = async () => {
+    setSaving(true);
+    await fetch(`/api/homes/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(form),
+    });
+    setSaving(false);
+    setEditMode(false);
+    // Tell Next.js to reload server data
+    router.refresh();
+  };
 
   return (
     <main className="min-h-screen bg-white px-8 py-12">
-      <h1 className="mb-4 text-3xl font-bold">Home #{id} Preview</h1>
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">Home #{id} Preview</h1>
+        <button
+          onClick={() => setEditMode((m) => !m)}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          {editMode ? "Cancel" : "Edit"}
+        </button>
+      </div>
 
-      {/* Display selected home image */}
-      <img
-        src={homeData.image}
-        alt={`Home ${id}`}
-        className="mb-6 w-full max-w-md rounded"
-      />
-
-      {/* Evolving preview based on quiz state */}
-      <LiveHomePreview />
-
-      {/* Listings section */}
-      <section className="mt-8">
-        <h2 className="mb-4 text-2xl">Available Listings</h2>
-        <ul className="list-inside list-disc">
-          {homeData.listings.map((listing, idx) => (
-            <li key={idx}>
-              <strong>{listing.title}</strong>: {listing.price}
-            </li>
-          ))}
-        </ul>
-      </section>
+      {editMode ? (
+        <div className="space-y-4 max-w-md">
+          <label className="block">
+            Bedrooms:
+            <input
+              type="number"
+              value={form.bedrooms}
+              onChange={(e) => onChange("bedrooms", +e.target.value)}
+              className="mt-1 w-full p-2 border rounded"
+            />
+          </label>
+          <label className="block">
+            Style:
+            <input
+              type="text"
+              value={form.style}
+              onChange={(e) => onChange("style", e.target.value)}
+              className="mt-1 w-full p-2 border rounded"
+            />
+          </label>
+          <label className="block">
+            Budget:
+            <input
+              type="text"
+              value={form.budget}
+              onChange={(e) => onChange("budget", e.target.value)}
+              className="mt-1 w-full p-2 border rounded"
+            />
+          </label>
+          <label className="block">
+            Image URL:
+            <input
+              type="text"
+              value={form.image}
+              onChange={(e) => onChange("image", e.target.value)}
+              className="mt-1 w-full p-2 border rounded"
+            />
+          </label>
+          {/* For simplicity, edit listings as JSON */}
+          <label className="block">
+            Listings (JSON):
+            <textarea
+              rows={4}
+              value={JSON.stringify(form.listings, null, 2)}
+              onChange={(e) => {
+                try {
+                  onChange(
+                    "listings",
+                    JSON.parse(e.target.value) as { title: string; price: string }[]
+                  );
+                } catch {
+                  // ignore parse errors
+                }
+              }}
+              className="mt-1 w-full p-2 border rounded font-mono text-sm"
+            />
+          </label>
+          <button
+            onClick={onSave}
+            disabled={saving}
+            className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700"
+          >
+            {saving ? "Saving…" : "Save Changes"}
+          </button>
+        </div>
+      ) : (
+        <>
+          <img
+            src={form.image}
+            alt={`Home ${id}`}
+            className="mb-6 w-full max-w-md rounded"
+          />
+          <LiveHomePreview />
+          <section className="mt-8 space-y-2">
+            <p>
+              <strong>Bedrooms:</strong> {form.bedrooms}
+            </p>
+            <p>
+              <strong>Style:</strong> {form.style}
+            </p>
+            <p>
+              <strong>Budget:</strong> {form.budget}
+            </p>
+            <div>
+              <strong>Listings:</strong>
+              <ul className="list-disc list-inside ml-4">
+                {form.listings.map((l, i) => (
+                  <li key={i}>
+                    {l.title}: {l.price}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        </>
+      )}
     </main>
   );
 }

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -1,12 +1,10 @@
 // src/app/homes/[id]/page.tsx
 import ClientHomePage from "./ClientHomePage";
-import homesData from "@/data/homes.json";
+import { getHome } from "@/data/homesStore";
 import { notFound } from "next/navigation";
 
-// Build pages for IDs 1–5 from homes.json
-export async function generateStaticParams() {
-  return homesData.map((h) => ({ id: h.id.toString() }));
-}
+// Force Next.js to skip cache and re-run this on every request
+export const dynamic = "force-dynamic";
 
 export default async function HomePage({
   params,
@@ -14,7 +12,7 @@ export default async function HomePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const home = homesData.find((h) => h.id.toString() === id);
-  if (!home) notFound();
+  const home = getHome(Number(id));
+  if (!home) return notFound();
   return <ClientHomePage id={id} homeData={home} />;
 }

--- a/src/app/homes/page.tsx
+++ b/src/app/homes/page.tsx
@@ -1,20 +1,109 @@
-// src/app/homes/page.tsx
-import Link from "next/link";
-import homesData from "@/data/homes.json";
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Home } from "@/data/homesStore";
 
 export default function HomesIndex() {
+  const [homes, setHomes] = useState<Home[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void (async () => {
+      const res = await fetch("/api/homes");
+      const data = (await res.json()) as unknown as Home[];
+      setHomes(data);
+      setLoading(false);
+    })();
+  }, []);
+
+  const handleChange = (
+    id: number,
+    field: keyof Home,
+    value: string | number
+  ) => {
+    setHomes((hs) =>
+      hs.map((h) =>
+        h.id === id
+          ? {
+              ...h,
+              [field]: value,
+            } as Home
+          : h
+      )
+    );
+  };
+
+  const save = async (home: Home) => {
+    const res = await fetch(`/api/homes/${home.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(home),
+    });
+    const updated = (await res.json()) as Home;
+    // Update local state so the UI reflects the change immediately
+    setHomes((hs) => hs.map((h) => (h.id === updated.id ? updated : h)));
+  };
+
+  if (loading) return <p className="p-8">Loading homes…</p>;
+
   return (
     <main className="min-h-screen bg-white px-8 py-12">
-      <h1 className="text-4xl font-bold mb-8">Demo Homes</h1>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {homesData.map((home) => (
-          <li key={home.id} className="border rounded-lg p-4 hover:shadow-lg">
-            <Link href={`/homes/${home.id}`} className="block">
-              <h2 className="text-2xl font-semibold mb-2">Home #{home.id}</h2>
-              <p>
-                {home.bedrooms} bed • {home.style} • {home.budget}
-              </p>
-            </Link>
+      <h1 className="text-4xl font-bold mb-8">Editable Homes Admin</h1>
+      <ul className="space-y-6">
+        {homes.map((h) => (
+          <li key={h.id} className="border p-6 rounded-lg">
+            <h2 className="text-2xl font-semibold mb-4">Home #{h.id}</h2>
+
+            <label className="block mb-2">
+              Bedrooms:
+              <input
+                type="number"
+                value={h.bedrooms}
+                onChange={(e) =>
+                  handleChange(h.id, "bedrooms", Number(e.target.value))
+                }
+                className="ml-2 p-1 border rounded w-20"
+              />
+            </label>
+
+            <label className="block mb-2">
+              Style:
+              <input
+                type="text"
+                value={h.style}
+                onChange={(e) =>
+                  handleChange(h.id, "style", e.target.value)
+                }
+                className="ml-2 p-1 border rounded"
+              />
+            </label>
+
+            <label className="block mb-2">
+              Budget:
+              <input
+                type="text"
+                value={h.budget}
+                onChange={(e) =>
+                  handleChange(h.id, "budget", e.target.value)
+                }
+                className="ml-2 p-1 border rounded"
+              />
+            </label>
+
+            <div className="mt-4 flex space-x-4">
+              <button
+                onClick={() => save(h)}
+                className="px-4 py-2 bg-emerald-600 text-white rounded hover:bg-emerald-700"
+              >
+                Save
+              </button>
+              <a
+                href={`/homes/${h.id}`}
+                className="px-4 py-2 border rounded hover:bg-gray-50"
+              >
+                View
+              </a>
+            </div>
           </li>
         ))}
       </ul>

--- a/src/data/homesStore.ts
+++ b/src/data/homesStore.ts
@@ -1,0 +1,44 @@
+// src/data/homesStore.ts
+
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export type Home = {
+  id: number;
+  bedrooms: number;
+  style: string;
+  budget: string;
+  image: string;
+  listings: { title: string; price: string }[];
+};
+
+const dataFile = join(process.cwd(), "src/data/homes.json");
+
+function readHomes(): Home[] {
+  const raw = readFileSync(dataFile, "utf8");
+  return JSON.parse(raw) as Home[];
+}
+
+function writeHomes(homes: Home[]) {
+  writeFileSync(dataFile, JSON.stringify(homes, null, 2));
+}
+
+export function getAllHomes() {
+  return readHomes();
+}
+
+export function getHome(id: number) {
+  return readHomes().find((h) => h.id === id);
+}
+
+export function updateHome(updated: Home) {
+  const homes = readHomes();
+  const idx = homes.findIndex((h) => h.id === updated.id);
+  if (idx >= 0) {
+    homes[idx] = updated;
+  } else {
+    homes.push(updated);
+  }
+  writeHomes(homes);
+  return updated;
+}


### PR DESCRIPTION
## Summary
- switch home data to a small JSON file so updates persist
- refresh the homes list after saving edits in `/homes` so new values show up immediately

## Testing
- `pnpm lint`
- `npx -y tsc --noEmit`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_6874513633c483229e8a00436ce97cbf